### PR TITLE
Fixed wait function with a default duration

### DIFF
--- a/sikuli/sikuli.py
+++ b/sikuli/sikuli.py
@@ -37,9 +37,7 @@ def findAll(target_string, *args, **kwargs):
     return screen.findAll(target)
 
 
-def wait(target_string, *args, **kwargs):
-    if not duration and duration != 0:
-        duration = 5000
+def wait(target_string, duration=5000, *args, **kwargs):
     target = Pattern(target_string).getTarget()
     screen = DesktopScreenRegion()
     return screen.wait(target, duration)


### PR DESCRIPTION
Fixed the wait function together with https://github.com/mnovait

This patch should close this bug: 
https://github.com/kevlened/sikuli_cpython/issues/7

duration was not initialized and caused this tracback:
UnboundLocalError: local variable 'duration' referenced before assignment